### PR TITLE
fix: Correct SourceComparisonPage render error and update sidebar i18n

### DIFF
--- a/app/(dashboard)/statistics/source-comparison/page.tsx
+++ b/app/(dashboard)/statistics/source-comparison/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import EnterprisePageHeader from '@/components/core/layout/EnterprisePageHeader';
 import QualityMetricCard from '@/components/ui/quality-metric-card';
-import { Database, CheckShield, BarChartBig, Filter as FilterIcon, ListChecks, TrendingUp } from 'lucide-react'; // CheckShield for quality, Added TrendingUp
+import { Database, ShieldCheck, BarChart2, Filter as FilterIcon, ListChecks, TrendingUp } from 'lucide-react'; // CheckShield for quality, Added TrendingUp
 
 interface DataSourceComparisonMetric {
   id: string;
@@ -38,8 +38,8 @@ const SourceComparisonPage = () => {
       <div className="p-6 md:p-10">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           <QualityMetricCard title="Total Data Sources" value={stats.totalSources.toLocaleString()} icon={<Database className="text-blue-600" />} />
-          <QualityMetricCard title="Highest Volume Source" value={stats.highestVolumeSource} icon={<BarChartBig className="text-emerald-600" />} />
-          <QualityMetricCard title="Best Quality Source" value={stats.bestQualitySource} icon={<CheckShield className="text-purple-600" />} />
+          <QualityMetricCard title="Highest Volume Source" value={stats.highestVolumeSource} icon={<BarChart2 className="text-emerald-600" />} />
+          <QualityMetricCard title="Best Quality Source" value={stats.bestQualitySource} icon={<ShieldCheck className="text-purple-600" />} />
         </div>
 
         {/* Filters Section */}

--- a/components/core/navigation/SidebarNav.tsx
+++ b/components/core/navigation/SidebarNav.tsx
@@ -57,11 +57,11 @@ export function SidebarNav() {
     icon: BarChart3,
     basePath: "/statistics",
     items: [
-      { titleKey: "statistics.overview", href: "/statistics", },
-      { titleKey: "statistics.collectionTrends", href: "/statistics/collection-trends" },
-      { titleKey: "statistics.geographicDistribution", href: "/statistics/geographic-distribution" },
-      { titleKey: "statistics.sectorDistribution", href: "/statistics/sector-distribution" },
-      { titleKey: "statistics.sourceComparison", href: "/statistics/source-comparison" },
+      { titleKey: "nav.statisticsOverview", href: "/statistics", },
+      { titleKey: "nav.statisticsCollectionTrends", href: "/statistics/collection-trends" },
+      { titleKey: "nav.statisticsGeographicDistribution", href: "/statistics/geographic-distribution" },
+      { titleKey: "nav.statisticsSectorDistribution", href: "/statistics/sector-distribution" },
+      { titleKey: "nav.statisticsSourceComparison", href: "/statistics/source-comparison" },
     ],
   };
 

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -24,6 +24,11 @@ export const translations = {
       leadResponse: "Lead Response",
       analytics: "Analytics",
       overview: "Overview",
+      statisticsOverview: "Overview",
+      statisticsCollectionTrends: "Collection Trends",
+      statisticsGeographicDistribution: "Geographic Distribution",
+      statisticsSectorDistribution: "Sector Distribution",
+      statisticsSourceComparison: "Source Comparison",
       secondary: {
         addCompany: "Add Company",
         importCompanies: "Import Companies",
@@ -611,6 +616,11 @@ export const translations = {
       leadResponse: "Réponse aux leads",
       analytics: "Analytique",
       overview: "Vue d'ensemble",
+      statisticsOverview: "Aperçu",
+      statisticsCollectionTrends: "Tendances de collecte",
+      statisticsGeographicDistribution: "Distribution géographique",
+      statisticsSectorDistribution: "Distribution par secteur",
+      statisticsSourceComparison: "Comparaison des sources",
       secondary: {
         addCompany: "Ajouter une entreprise",
         importCompanies: "Importer des entreprises",


### PR DESCRIPTION
This commit addresses two issues you pointed out:

1.  **Fix Rendering Error in `SourceComparisonPage`:**
    *   I corrected potentially invalid icon names imported from `lucide-react` in `app/(dashboard)/statistics/source-comparison/page.tsx`.
    *   I changed `BarChartBig` to `BarChart2` and `CheckShield` to `ShieldCheck` to resolve the element type error.

2.  **Update Sidebar UI Text and Translations for Statistics Sub-links:**
    *   I modified `components/core/navigation/SidebarNav.tsx` to use new, specific internationalization keys for the statistics sub-page navigation links (e.g., `nav.statisticsCollectionTrends` instead of `statistics.collectionTrends`).
    *   I added these new keys with their corresponding English titles and French translations to `lib/i18n/translations.ts` under the `nav` object.
    *   This ensures the sidebar displays human-readable, translatable names for these navigation items.